### PR TITLE
MAID-736 Introduce default constructor for Passport::detail::PublicFob()

### DIFF
--- a/include/maidsafe/passport/detail/public_fob.h
+++ b/include/maidsafe/passport/detail/public_fob.h
@@ -44,7 +44,7 @@ class PublicFob {
   typedef Fob<typename SignerFob<TagType>::Tag> Signer;
   typedef TaggedValue<NonEmptyString, Tag> serialised_type;
 
-  PublicFob() = delete;
+  PublicFob() = default;
 
   PublicFob(const PublicFob& other)
       : name_(other.name_),


### PR DESCRIPTION
Necessary for Routing_v2